### PR TITLE
Issue #14 expose %config and %noreplace directives

### DIFF
--- a/src/main/groovy/com/riotgames/maven/redline/Mapping.groovy
+++ b/src/main/groovy/com/riotgames/maven/redline/Mapping.groovy
@@ -16,6 +16,11 @@ class Mapping {
     def int filemode
 
     def int dirmode
+	
+	def boolean config
+	
+	def boolean noreplace
+	
 
     /**
      * A List of source files that will be installed into the rpm
@@ -27,6 +32,8 @@ class Mapping {
         this.groupname = CpioHeader.DEFAULT_GROUP
         this.filemode = CpioHeader.DEFAULT_FILE_PERMISSION
         this.dirmode = CpioHeader.DEFAULT_DIRECTORY_PERMISSION
+		this.config = false;
+		this.noreplace = false;
     }
 
     @Override


### PR DESCRIPTION
Simple solution built to resemble sample from Redlilne

``` xml
<rpmfileset prefix="/tmp/rpmtest/conf" config="true" noreplace="true" file="conf/test1.conf"
              filemode="644" username="none" group="none"/>
```

(i.e. config="true" noreplace="true")

and current handling of file owner / file mode like this:

``` xml
            <mapping>
                <directory>/etc/some/config</directory>
                <!-- ... -->
                <config>true</config>
                <noreplace>true</noreplace>
                <sources>
                    <source>${project.basedir}/target/someFile.txt</source>
                </sources>
            </mapping>
```

Someone may add a full Directive handling (as Redline seems to support it well in the Java API) but this would require some more complex design decisions about how the XML for that should look like, so this is at least a shortcut.

Detailts on the meaning of config versus noreplace may be found here: http://www-uxsup.csx.cam.ac.uk/~jw35/docs/rpm_config.html
